### PR TITLE
qml: Added support for attributes in extra

### DIFF
--- a/obspy/core/quakeml.py
+++ b/obspy/core/quakeml.py
@@ -894,6 +894,7 @@ class Pickler(object):
             # check if a namespace is given
             if isinstance(value, dict):
                 ns = value.get("_namespace")
+                xtype = value.get("_type")
                 value = value.get("value")
             # otherwise use default obspy namespace (and add it to
             if ns is None:
@@ -908,7 +909,10 @@ class Pickler(object):
                     ns_abbrev, ns = ns
                 self._addNamespace(ns, ns_abbrev)
             tag = "{%s}%s" % (ns, key)
-            self._str(value, element, tag)
+            if xtype is "attribute":
+                element.attrib[tag] = value
+            else:
+                self._str(value, element, tag)
 
     def _getNamespaceMap(self):
         nsmap = self.ns_dict.copy()


### PR DESCRIPTION
In quakeml Pickler._extra, Added a check for a "_type" key in each value of "extra". Adds the value to the element's attrib dictionary if "_type" is "attribute".

Didn't see a test for 'extra' yet, but this:

``` python
e = Event()
e.extra = {'dataid': {'_namespace': ['catalog', 'http://anss.org/xmlns/catalog/0.1'],
    '_type': 'attribute',
    'value': '00999999'}}
c= Catalog(events=[e])
print Pickler().dumps(c)
```

gets you:

```
<?xml version='1.0' encoding='utf-8'?>
<q:quakeml xmlns:q="http://quakeml.org/xmlns/quakeml/1.2" xmlns:catalog="http://anss.org/xmlns/catalog/0.1" xmlns="http://quakeml.org/xmlns/bed/1.2">
  <eventParameters publicID="smi:local/0b8ab6cc-c6de-4e95-bfb3-7fcdbaf08cf9">
    <event publicID="smi:local/e8b8bcf5-629b-4404-b666-8e1728cdc5ba" catalog:dataid="00999999"/>
  </eventParameters>
</q:quakeml>
```
